### PR TITLE
Move openvswitch db file into docker volume

### DIFF
--- a/docker/openvswitch/openvswitch-db-server/extend_start.sh
+++ b/docker/openvswitch/openvswitch-db-server/extend_start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 mkdir -p "/run/openvswitch"
-if [[ ! -e "/etc/openvswitch/conf.db" ]]; then
-    ovsdb-tool create "/etc/openvswitch/conf.db"
+if [[ ! -e "/var/lib/openvswitch/conf.db" ]]; then
+    ovsdb-tool create "/var/lib/openvswitch/conf.db"
 fi

--- a/docker/openvswitch/openvswitch-db-server/start_ovsdb_server.sh
+++ b/docker/openvswitch/openvswitch-db-server/start_ovsdb_server.sh
@@ -19,12 +19,12 @@ ovs_ext_intf=$3
 if [ ! -e $ovs_bridge  ] && [ ! -e $ovs_ext_intf  ]; then
 # NOTE: (sbezverk) This part is executed only by kubernetes deployment.
 # Creating external bridge
-    /usr/sbin/ovsdb-server /etc/openvswitch/conf.db --remote=punix:/var/run/openvswitch/db.sock --run="ovs-vsctl --no-wait --db=unix:/var/run/openvswitch/db.sock add-br $ovs_bridge"
+    /usr/sbin/ovsdb-server /var/lib/openvswitch/conf.db --remote=punix:/var/run/openvswitch/db.sock --run="ovs-vsctl --no-wait --db=unix:/var/run/openvswitch/db.sock add-br $ovs_bridge"
 # Plug the external interface into the external bridge.
-    /usr/sbin/ovsdb-server /etc/openvswitch/conf.db --remote=punix:/var/run/openvswitch/db.sock --run="ovs-vsctl --no-wait --db=unix:/var/run/openvswitch/db.sock add-port $ovs_bridge $ovs_ext_intf"
+    /usr/sbin/ovsdb-server /var/lib/openvswitch/conf.db --remote=punix:/var/run/openvswitch/db.sock --run="ovs-vsctl --no-wait --db=unix:/var/run/openvswitch/db.sock add-port $ovs_bridge $ovs_ext_intf"
 # Run ovsdb server proces
-    /usr/sbin/ovsdb-server /etc/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/var/run/openvswitch/db.sock --remote=ptcp:6640 --log-file=/var/log/kolla/openvswitch/ovsdb-server.log
+    /usr/sbin/ovsdb-server /var/lib/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/var/run/openvswitch/db.sock --remote=ptcp:6640 --log-file=/var/log/kolla/openvswitch/ovsdb-server.log
 else
 # NOTE: (sbezverk) This part is executed only by kolla-ansible deployment.
-    /usr/sbin/ovsdb-server /etc/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/run/openvswitch/db.sock --remote=ptcp:6640:$ovsdb_ip --log-file=/var/log/kolla/openvswitch/ovsdb-server.log
+    /usr/sbin/ovsdb-server /var/lib/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/run/openvswitch/db.sock --remote=ptcp:6640:$ovsdb_ip --log-file=/var/log/kolla/openvswitch/ovsdb-server.log
 fi


### PR DESCRIPTION
openvswitch db file is created in /etc/openvswitch/conf.db. It will be
lost during upgrade openvswitch_db container.

This patch moves the db file into /var/lib/openvswitch folder, which
located in docker volume.

Change-Id: I73604fddacd21655590b9e66ee2805014795b9f1
Closes-Bug: #1649290
(cherry picked from commit f62b16f8a447b7c90da3844720a200fb4d3ef5d5)